### PR TITLE
5주차

### DIFF
--- a/src/main/java/community/project/community/Board/controller/BoardRestController.java
+++ b/src/main/java/community/project/community/Board/controller/BoardRestController.java
@@ -1,13 +1,18 @@
 package community.project.community.Board.controller;
 
 import community.project.community.Board.entity.Board;
+import community.project.community.Board.entity.BoardComment;
 import community.project.community.Board.exception.BoardNotFoundException;
+import community.project.community.Board.model.BoardCommentInput;
+import community.project.community.Board.model.BoardDeleteInput;
 import community.project.community.Board.model.BoardInput;
 import community.project.community.Board.model.BoardModifyInput;
 import community.project.community.Board.repository.BoardRepository;
+import community.project.community.Board.service.BoardCommentService;
 import community.project.community.Board.service.BoardService;
 import community.project.community.client.repository.UserRepository;
 import io.swagger.annotations.ApiOperation;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,20 +31,21 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class BoardController {
+public class BoardRestController {
 
   private final BoardRepository boardRepository;
-  private final UserRepository userRepository;
   private final BoardService boardService;
+  private final BoardCommentService boardCommentService;
 
 
   //특정 게시판 글 가져오기
   @ApiOperation(value = "특정 게시판 글 불러오기", notes = "게시판 고유ID를 입력해주세요.")
   @GetMapping("/board/list/{boardId}")
   public Board boardList(@PathVariable long boardId) {
-    Optional<Board> board = boardRepository.findById(boardId);
-    //예외처리 필요
-    return board.get();
+    Board board = boardRepository.findById(boardId)
+        .orElseThrow(() -> new BoardNotFoundException("해당하는 게시판이 존재하지 않습니다."));
+
+    return board;
   }
 
   //게시판 글 목록 가져오기
@@ -51,15 +57,23 @@ public class BoardController {
     return boardList;
   }
 
+  //특정 유저가 작성한 글 목록 가져오기
+  @ApiOperation(value = "특정 유저가 작성한 글 목록 가져오기")
+  @GetMapping("/board/find/list/{userId}")
+  public ResponseEntity<?> findBoardList(@PathVariable String userId) {
+    List<Board> boardList = boardRepository.findByUserId(userId);
+
+    return ResponseEntity.ok().body(boardList);
+  }
+
   //게시판 글 추가
-  @ApiOperation(value = "게시판 글 작성", notes = "회원 고유ID 입력 후 제목과 내용을 입력해주세요. 업로드할 파일이 있다면 올려주세요.")
+  @ApiOperation(value = "게시판 글 작성", notes = "회원 ID 입력 후 제목과 내용을 입력해주세요. 업로드할 파일이 있다면 올려주세요.")
   @PostMapping("/board/add")
   public ResponseEntity addBoard(@ModelAttribute BoardInput boardInput) {
 
     //게시글 작성
-    boardService.addBoard(boardInput);
+    Board board = boardService.addBoard(boardInput);
 
-    Board board = boardRepository.findByUserId(boardInput.getUserId());
     return ResponseEntity.ok()
         .body("게시글이 정상적으로 업로드 되었습니다. 게시글의 등록번호는" + board.getBoardId() + "입니다.");
   }
@@ -67,21 +81,39 @@ public class BoardController {
   //게시판 글 삭제
   @ApiOperation(value = "게시판 삭제하기", notes = "삭제할 게시판의 고유 Id를 입력해주세요.")
   @DeleteMapping("/board/delete/{boardId}")
-  public ResponseEntity deleteBoard(@ModelAttribute @PathVariable long boardId) {
-    Board board = boardRepository.findById(boardId)
-        .orElseThrow(() -> new BoardNotFoundException("해당하는 게시판이 존재하지 않습니다."));
-    boardRepository.deleteById(boardId);
+  public ResponseEntity deleteBoard(@ModelAttribute BoardDeleteInput boardDeleteInput) {
+
+    boolean result = boardService.deleteBoard(boardDeleteInput);
+    if(!result){
+      return ResponseEntity.badRequest().body("게시글이 삭제가 실패했습니다.");
+    }
+
     return ResponseEntity.ok().body("정상적으로 삭제되었습니다.");
   }
 
   //게시판 글 수정
+  @ApiOperation(value = "게시판 작성글 수정하기", notes = "수정할 게시판의 고유 Id를 입력해주세요.")
   @PatchMapping("/board/modify")
-  public ResponseEntity modifyBoard(@ModelAttribute BoardModifyInput boardModifyInput) {
+  public ResponseEntity<?> modifyBoard(@ModelAttribute BoardModifyInput boardModifyInput) {
 
-    boardService.modifyBoard(boardModifyInput);
+    Board board = boardService.modifyBoard(boardModifyInput);
 
-    Board board = boardRepository.findByUserId(boardModifyInput.getUserId());
     return ResponseEntity.ok().body("게시글 수정을 완료하였습니다: " + board);
+  }
+
+  //게시판 댓글 작성
+
+  @ApiOperation(value = "게시글 댓글 작성")
+  @PostMapping("/board/write/comment")
+  public ResponseEntity addBoardComment(@ModelAttribute BoardCommentInput boardCommentInput) {
+
+
+    //게시글 댓글 작성
+    BoardComment boardComment = boardCommentService.addComment(boardCommentInput.getBoardId(),boardCommentInput.getUserId(),
+        boardCommentInput.getComment());
+
+    return ResponseEntity.ok()
+        .body("댓글이 정상적으로 업로드 되었습니다."+boardComment);
   }
 
 }

--- a/src/main/java/community/project/community/Board/entity/Board.java
+++ b/src/main/java/community/project/community/Board/entity/Board.java
@@ -1,6 +1,7 @@
 package community.project.community.Board.entity;
 
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;

--- a/src/main/java/community/project/community/Board/entity/BoardComment.java
+++ b/src/main/java/community/project/community/Board/entity/BoardComment.java
@@ -1,0 +1,39 @@
+package community.project.community.Board.entity;
+
+import community.project.community.client.entity.User;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardComment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  @NotBlank
+  private String comment;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Board board;
+
+}
+
+

--- a/src/main/java/community/project/community/Board/entity/BoardLikeHate.java
+++ b/src/main/java/community/project/community/Board/entity/BoardLikeHate.java
@@ -1,0 +1,37 @@
+package community.project.community.Board.entity;
+
+import community.project.community.client.entity.User;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardLikeHate {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String value;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Board board;
+
+}
+
+

--- a/src/main/java/community/project/community/Board/model/BoardCommentInput.java
+++ b/src/main/java/community/project/community/Board/model/BoardCommentInput.java
@@ -1,0 +1,28 @@
+package community.project.community.Board.model;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardCommentInput {
+
+  //작성자 정보
+  @NotBlank(message = "작성자 정보는 필수로 입력해야 합니다.")
+  private String userId;
+
+  //게시글 정보
+  @NotBlank(message = "게시글 정보는 필수로 입력해야 합니다.")
+  private long boardId;
+
+  //댓글 내용
+  @NotBlank(message = "댓글은 필수 항목입니다.")
+  private String comment;
+
+}

--- a/src/main/java/community/project/community/Board/model/BoardDeleteInput.java
+++ b/src/main/java/community/project/community/Board/model/BoardDeleteInput.java
@@ -1,0 +1,21 @@
+package community.project.community.Board.model;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardDeleteInput {
+
+  @NotBlank(message = "삭제할 게시글 번호는 필수입니다.")
+  private long boardId;
+
+  @NotBlank(message = "삭제를 시도하는 유저의 아이디를 입력하세요.")
+  private String userId;
+
+}

--- a/src/main/java/community/project/community/Board/repository/BoardCommentRepository.java
+++ b/src/main/java/community/project/community/Board/repository/BoardCommentRepository.java
@@ -1,0 +1,10 @@
+package community.project.community.Board.repository;
+
+import community.project.community.Board.entity.Board;
+import community.project.community.Board.entity.BoardComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
+
+
+}

--- a/src/main/java/community/project/community/Board/repository/BoardLikeHateRepository.java
+++ b/src/main/java/community/project/community/Board/repository/BoardLikeHateRepository.java
@@ -1,0 +1,9 @@
+package community.project.community.Board.repository;
+
+import community.project.community.Board.entity.BoardLikeHate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardLikeHateRepository extends JpaRepository<BoardLikeHate, Long> {
+
+
+}

--- a/src/main/java/community/project/community/Board/repository/BoardRepository.java
+++ b/src/main/java/community/project/community/Board/repository/BoardRepository.java
@@ -2,6 +2,7 @@ package community.project.community.Board.repository;
 
 import community.project.community.Board.entity.Board;
 import community.project.community.client.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BoardRepository extends JpaRepository<Board,Long> {
 
-  Board findByUserId(String userId);
+  Optional<Board> findByBoardId(long boardId);
+  List<Board> findByUserId(String userId);
 
 }

--- a/src/main/java/community/project/community/Board/service/BoardCommentService.java
+++ b/src/main/java/community/project/community/Board/service/BoardCommentService.java
@@ -1,0 +1,9 @@
+package community.project.community.Board.service;
+
+import community.project.community.Board.entity.BoardComment;
+
+public interface BoardCommentService {
+
+  BoardComment addComment(long boardId, String userId,String comment);
+
+}

--- a/src/main/java/community/project/community/Board/service/BoardService.java
+++ b/src/main/java/community/project/community/Board/service/BoardService.java
@@ -1,5 +1,7 @@
 package community.project.community.Board.service;
 
+import community.project.community.Board.entity.Board;
+import community.project.community.Board.model.BoardDeleteInput;
 import community.project.community.Board.model.BoardInput;
 import community.project.community.Board.model.BoardModifyInput;
 
@@ -9,8 +11,10 @@ public interface BoardService {
   String[] getNewSaveFile(String baseLocalPath, String baseUrlPath,
       String originalFilename);
 
-  boolean addBoard(BoardInput boardInput);
+  Board addBoard(BoardInput boardInput);
 
-  boolean modifyBoard(BoardModifyInput boardModifyInput);
+  Board modifyBoard(BoardModifyInput boardModifyInput);
+
+  boolean deleteBoard(BoardDeleteInput boardDeleteInput);
 
 }

--- a/src/main/java/community/project/community/Board/service/implement/BoardCommentServiceImpl.java
+++ b/src/main/java/community/project/community/Board/service/implement/BoardCommentServiceImpl.java
@@ -1,0 +1,56 @@
+package community.project.community.Board.service.implement;
+
+import community.project.community.Board.entity.Board;
+import community.project.community.Board.entity.BoardComment;
+import community.project.community.Board.exception.BoardModifyNotMatchUserException;
+import community.project.community.Board.exception.BoardNotFoundException;
+import community.project.community.Board.model.BoardInput;
+import community.project.community.Board.model.BoardModifyInput;
+import community.project.community.Board.repository.BoardCommentRepository;
+import community.project.community.Board.repository.BoardRepository;
+import community.project.community.Board.service.BoardCommentService;
+import community.project.community.Board.service.BoardService;
+import community.project.community.client.entity.User;
+import community.project.community.client.exception.UserNotFoundException;
+import community.project.community.client.repository.UserRepository;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.FileCopyUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BoardCommentServiceImpl implements BoardCommentService {
+
+  private final UserRepository userRepository;
+
+  private final BoardRepository boardRepository;
+
+  private final BoardCommentRepository boardCommentRepository;
+
+
+  @Override
+  public BoardComment addComment(long boardId, String userId, String comment) {
+    Optional<Board> board = Optional.ofNullable(boardRepository.findByBoardId(boardId)
+        .orElseThrow(() -> new BoardNotFoundException("해당 게시글이 존재하지 않습니다.")));
+    Optional<User> user = Optional.ofNullable(userRepository.findByUserId(userId)
+        .orElseThrow(() -> new UserNotFoundException("해당 유저가 존재하지 않습니다.")));
+
+    BoardComment boardComment = BoardComment.builder()
+        .comment(comment)
+        .board(board.get())
+        .user(user.get())
+        .build();
+
+    boardCommentRepository.save(boardComment);
+    return boardComment;
+  }
+}

--- a/src/main/java/community/project/community/Board/service/implement/BoardCommentServiceImpl.java
+++ b/src/main/java/community/project/community/Board/service/implement/BoardCommentServiceImpl.java
@@ -37,13 +37,17 @@ public class BoardCommentServiceImpl implements BoardCommentService {
   private final BoardCommentRepository boardCommentRepository;
 
 
+  //댓글 작성
   @Override
   public BoardComment addComment(long boardId, String userId, String comment) {
+
+    //댓글 작성 전, 게시글 존재와 유저 존재 여부
     Optional<Board> board = Optional.ofNullable(boardRepository.findByBoardId(boardId)
         .orElseThrow(() -> new BoardNotFoundException("해당 게시글이 존재하지 않습니다.")));
     Optional<User> user = Optional.ofNullable(userRepository.findByUserId(userId)
         .orElseThrow(() -> new UserNotFoundException("해당 유저가 존재하지 않습니다.")));
 
+    //댓글 작성
     BoardComment boardComment = BoardComment.builder()
         .comment(comment)
         .board(board.get())

--- a/src/main/java/community/project/community/Board/service/implement/BoardServiceImpl.java
+++ b/src/main/java/community/project/community/Board/service/implement/BoardServiceImpl.java
@@ -122,10 +122,13 @@ public class BoardServiceImpl implements BoardService {
     return board;
   }
 
+  //게시글 삭제
   @Override
   public boolean deleteBoard(BoardDeleteInput boardDeleteInput) {
+
+    //삭제 시도 전, 게시글, 유저 정보 판단
     Board board = boardRepository.findById(boardDeleteInput.getBoardId())
-        .orElseThrow(() -> new BoardNotFoundException("해당하는 게시판이 존재하지 않습니다."));
+        .orElseThrow(() -> new BoardNotFoundException("해당하는 게시글이 존재하지 않습니다."));
 
     User user = userRepository.findByUserId(boardDeleteInput.getUserId())
             .orElseThrow(() -> new UserNotFoundException("유저 정보가 존재하지 않습니다."));

--- a/src/main/java/community/project/community/Board/service/implement/BoardServiceImpl.java
+++ b/src/main/java/community/project/community/Board/service/implement/BoardServiceImpl.java
@@ -3,6 +3,7 @@ package community.project.community.Board.service.implement;
 import community.project.community.Board.entity.Board;
 import community.project.community.Board.exception.BoardModifyNotMatchUserException;
 import community.project.community.Board.exception.BoardNotFoundException;
+import community.project.community.Board.model.BoardDeleteInput;
 import community.project.community.Board.model.BoardInput;
 import community.project.community.Board.model.BoardModifyInput;
 import community.project.community.Board.repository.BoardRepository;
@@ -26,12 +27,13 @@ import org.springframework.util.FileCopyUtils;
 @Service
 @RequiredArgsConstructor
 public class BoardServiceImpl implements BoardService {
+
   private final UserRepository userRepository;
 
   private final BoardRepository boardRepository;
 
   @Override
-  public boolean addBoard(BoardInput boardInput) {
+  public Board addBoard(BoardInput boardInput) {
 
     String saveFilename = "";
     String urlFilename = "";
@@ -69,18 +71,18 @@ public class BoardServiceImpl implements BoardService {
         .urlFilename(urlFilename)
         .build());
 
-    return true;
+    return board;
   }
 
 
   //게시글 수정
   @Override
-  public boolean modifyBoard(BoardModifyInput boardModifyInput) {
+  public Board modifyBoard(BoardModifyInput boardModifyInput) {
 
     Board board = boardRepository.findById(boardModifyInput.getBoardId())
         .orElseThrow(() -> new BoardNotFoundException("해당하는 게시판이 존재하지 않습니다."));
 
-    if (!(board.getUserId() == boardModifyInput.getUserId())) {
+    if (!(board.getUserId().equals(boardModifyInput.getUserId()))) {
       throw new BoardModifyNotMatchUserException("게시글 수정의 권한이 없습니다.");
     }
 
@@ -113,9 +115,30 @@ public class BoardServiceImpl implements BoardService {
       board.setUrlFilename(urlFilename);
     }
 
+    log.info("게시글" + board.getBoardId() + "글이 수정되었습니다.");
+
     boardRepository.save(board);
 
-    return false;
+    return board;
+  }
+
+  @Override
+  public boolean deleteBoard(BoardDeleteInput boardDeleteInput) {
+    Board board = boardRepository.findById(boardDeleteInput.getBoardId())
+        .orElseThrow(() -> new BoardNotFoundException("해당하는 게시판이 존재하지 않습니다."));
+
+    User user = userRepository.findByUserId(boardDeleteInput.getUserId())
+            .orElseThrow(() -> new UserNotFoundException("유저 정보가 존재하지 않습니다."));
+
+    //게시글을 작성한 유저와 삭제를 시도하는 유저가 다른 경우
+    if(!user.getUserId().equals(board.getUserId())){
+      log.info("삭제하려는 유저와 게시글을 작성한 유저가 일치하지 않습니다.");
+      return false;
+    }
+
+    log.info("게시글" + board.getBoardId() + "글이 삭제 되었습니다.");
+    boardRepository.deleteById(boardDeleteInput.getBoardId());
+    return true;
   }
 
   //등록된 파일 저장
@@ -155,8 +178,6 @@ public class BoardServiceImpl implements BoardService {
     }
     return new String[]{newFilename, newUrlFilename};
   }
-
-
 
 
 }

--- a/src/main/java/community/project/community/admin/AdminRestController.java
+++ b/src/main/java/community/project/community/admin/AdminRestController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class AdminController {
+public class AdminRestController {
 
   private final UserRepository userRepository;
 

--- a/src/main/java/community/project/community/client/controller/UserController.java
+++ b/src/main/java/community/project/community/client/controller/UserController.java
@@ -1,173 +1,27 @@
 package community.project.community.client.controller;
 
-import community.project.community.client.entity.User;
-import community.project.community.client.enums.UserRole;
-import community.project.community.client.enums.UserStatus;
-import community.project.community.client.exception.AlreadyRegistEmail;
-import community.project.community.client.exception.UserLoginNotCorrectPasswordException;
-import community.project.community.client.exception.UserNotEmailAuthException;
-import community.project.community.client.exception.UserNotFoundException;
-import community.project.community.client.model.ResponseError;
-import community.project.community.client.model.UserInput;
-import community.project.community.client.model.UserInputLogin;
-import community.project.community.client.model.UserInputPassword;
-import community.project.community.client.repository.UserRepository;
 import community.project.community.client.service.UserService;
-import community.project.community.components.MailComponents;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.Errors;
-import org.springframework.validation.FieldError;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
-@RestController
+@Controller
 @AllArgsConstructor
-@Slf4j
+@ApiIgnore
 public class UserController {
 
-  private final UserRepository userRepository;
-
-  private final MailComponents mailComponents;
   private final UserService userService;
-
-
-  //회원가입
-  @ApiOperation(value = "회원가입", notes = "회원가입API 입니다. 해당하는 입력값을 넣어주세요.")
-  @PostMapping("/user/register")
-  public ResponseEntity<?> userRegister(
-      @ModelAttribute @Valid @ApiParam(value = "사용자 아이디와 비밀번호 : ") UserInput userInput
-      , @ApiIgnore Errors error) {
-
-    List<ResponseError> responseErrorList = new ArrayList<>();
-    if (error.hasErrors()) {
-      error.getAllErrors().stream().forEach((e) -> {
-        responseErrorList.add(ResponseError.of((FieldError) e));
-      });
-      return ResponseEntity.badRequest().body(responseErrorList);
-    }
-
-    //동일한 이메일 계정이 있다면 예외처리
-    userService.checkSameEmail(userInput.getUserId());
-
-    //회원 정보 저장
-    userService.register(userInput);
-    
-    Optional<User> user = userRepository.findByUserId(userInput.getUserId());
-
-    return ResponseEntity.ok()
-        .body("회원가입에 성공하였습니다. 회원 고유 Id값은 "+user.get().getId()+"입니다. 이메일을 통해 인증해주세요.");
-  }
 
   //이메일 인증
   @ApiIgnore
   @GetMapping("/member/email-auth")
   public String emailAuth(HttpServletRequest request) {
     String uuid = request.getParameter("id");
-    userService.emailAuth(uuid);
-    return "이메일 인증 완료";
-  }
-
-  //로그인
-  @ApiOperation(value = "로그인", notes = "로그인API 입니다. 아이디와 비밀번호를 입력하세요.")
-  @PostMapping("/user/login")
-  public ResponseEntity<?> userLogin(@ModelAttribute UserInputLogin userInputLogin
-      , @ApiIgnore Errors error) {
-    List<ResponseError> responseErrorList = new ArrayList<>();
-    if (error.hasErrors()) {
-      error.getAllErrors().stream().forEach((e) -> {
-        responseErrorList.add(ResponseError.of((FieldError) e));
-      });
-      return ResponseEntity.badRequest().body(responseErrorList);
-    }
-
-    Optional<User> optionalUserser = Optional.ofNullable(
-        userRepository.findByUserId(userInputLogin.getUserId())
-            .orElseThrow(() -> new UserNotFoundException("존재하지 않는 계정입니다.")));
-    User user = optionalUserser.get();
-
-    //이메일 인증이 되어있는지 확인
-    if (!user.isEmailAuthYn()) {
-      return ResponseEntity.badRequest().body(new UserNotEmailAuthException("먼저 이메일 인증을 해주세요."));
-    }
-
-    //패스워드 확인
-    if (!userService.loginCheckPassword(userInputLogin.getPassword(), user.getPassword())) {
-      return ResponseEntity.badRequest()
-          .body(new UserLoginNotCorrectPasswordException("아이디와 비밀번호가 일치하지 않습니다."));
-    }
-    log.info("로그인 성공");
-    return ResponseEntity.ok().body("로그인에 성공하였습니다.");
-  }
-
-  //비밀번호 수정
-  @ApiOperation(value = "비밀번호 수정", notes = "비밀번호 수정 API 입니다. 해당하는 입력값을 넣어주세요.")
-  @PatchMapping("/user/{id}/setPassword")
-  public ResponseEntity<?> updateUserPassword(@PathVariable Long id,
-      @ModelAttribute UserInputPassword userInputPassword
-      , @ApiIgnore Errors errors) {
-    List<ResponseError> responseErrorList = new ArrayList<>();
-    if (errors.hasErrors()) {
-      errors.getAllErrors().stream().forEach((e) -> {
-        responseErrorList.add(ResponseError.of((FieldError) e));
-      });
-      return ResponseEntity.badRequest().body(responseErrorList);
-    }
-
-    User user = userRepository.findById(id)
-        .orElseThrow(() -> new UserNotFoundException("해당하는 계정이 없습니다."));
-
-    //아이디와 비밀번호 확인
-    if (!userService.loginCheckPassword(userInputPassword.getPassword(), user.getPassword())) {
-      return ResponseEntity.badRequest()
-          .body(new UserLoginNotCorrectPasswordException("아이디와 비밀번호가 일치하지 않습니다."));
-    }
-    user.setPassword(userService.getEncryptPassword(userInputPassword.getNewPassword()));
-    userRepository.save(user);
-
-    return ResponseEntity.ok().body("비밀번호가 정상적으로 수정되었습니다.");
-  }
-
-
-  //회원탈퇴
-  @ApiOperation(value = "회원탈퇴", notes = "회원탈퇴API 입니다. 해당하는 입력값을 넣어주세요.")
-  @PostMapping("/user/delete/{id}")
-  public ResponseEntity<?> userDelete(@PathVariable Long id) {
-    User user = userRepository.findById(id)
-        .orElseThrow(() -> new UserNotFoundException("사용자 정보가 존재하지 않습니다."));
-
-    //해당 아이디의 사용자가 탈퇴를 하려는데
-    //사용자가 작성한 게시글이 있는경우 예외 발생
-
-    try {
-      userRepository.delete(user);
-    } catch (DataIntegrityViolationException e) {
-      String message = "제약조건에 문제가 발생하였습니다.";
-      return ResponseEntity.badRequest()
-          .body(message);
-    } catch (Exception e) {
-      String message = "회원 탈퇴 중 문제가 발생하였습니다.";
-      return ResponseEntity.badRequest()
-          .body(message);
-    }
-
-    return ResponseEntity.ok().body("회원 탈퇴가 정상적으로 진행되었습니다.");
+    boolean result = userService.emailAuth(uuid);
+    return "client/email-auth";
   }
 
 }

--- a/src/main/java/community/project/community/client/controller/UserController.java
+++ b/src/main/java/community/project/community/client/controller/UserController.java
@@ -19,6 +19,8 @@ public class UserController {
   @ApiIgnore
   @GetMapping("/member/email-auth")
   public String emailAuth(HttpServletRequest request) {
+
+    //이메일 인증 화면을 페이지로 띄우기 위해 Controller로 정의
     String uuid = request.getParameter("id");
     boolean result = userService.emailAuth(uuid);
     return "client/email-auth";

--- a/src/main/java/community/project/community/client/controller/UserRestController.java
+++ b/src/main/java/community/project/community/client/controller/UserRestController.java
@@ -1,0 +1,191 @@
+package community.project.community.client.controller;
+
+import community.project.community.client.entity.User;
+import community.project.community.client.exception.UserLoginNotCorrectPasswordException;
+import community.project.community.client.exception.UserNotEmailAuthException;
+import community.project.community.client.exception.UserNotFoundException;
+import community.project.community.client.model.ResponseError;
+import community.project.community.client.model.UserInput;
+import community.project.community.client.model.UserInputFindUserId;
+import community.project.community.client.model.UserInputLogin;
+import community.project.community.client.model.UserInputPassword;
+import community.project.community.client.repository.UserRepository;
+import community.project.community.client.service.UserService;
+import community.project.community.components.MailComponents;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+@RestController
+@AllArgsConstructor
+@Slf4j
+public class UserRestController {
+
+  private final UserRepository userRepository;
+
+  private final MailComponents mailComponents;
+  private final UserService userService;
+
+
+  //회원가입
+  @ApiOperation(value = "회원가입", notes = "회원가입API 입니다. 해당하는 입력값을 넣어주세요.")
+  @PostMapping("/user/register")
+  public ResponseEntity<?> userRegister(
+      @ModelAttribute @Valid @ApiParam(value = "사용자 아이디와 비밀번호 : ") UserInput userInput
+      , @ApiIgnore Errors error) {
+
+    List<ResponseError> responseErrorList = new ArrayList<>();
+    if (error.hasErrors()) {
+      error.getAllErrors().stream().forEach((e) -> {
+        responseErrorList.add(ResponseError.of((FieldError) e));
+      });
+      return ResponseEntity.badRequest().body(responseErrorList);
+    }
+
+    //동일한 이메일 계정이 있다면 예외처리
+    userService.checkSameEmail(userInput.getUserId());
+
+    //회원 정보 저장
+    userService.register(userInput);
+
+    Optional<User> optionalUser = userRepository.findByUserId(userInput.getUserId());
+    User user = optionalUser.get();
+
+    log.info("###회원가입 진행###");
+    log.info("이름: " + user.getUserName() + ", 유저 아이디: " + user.getUserId() + " 가입이 이루어 졌습니다.");
+
+    return ResponseEntity.ok()
+        .body("회원가입에 성공하였습니다. 회원 고유 Id값은 " + user.getId() + "입니다. 이메일을 통해 인증해주세요.");
+  }
+
+  /*//이메일 인증
+  @ApiIgnore
+  @GetMapping("/member/email-auth")
+  public boolean emailAuth(HttpServletRequest request) {
+    String uuid = request.getParameter("id");
+    boolean result = userService.emailAuth(uuid);
+    if (!result) {
+      return false;
+    }
+    log.info("이메일 인증에 성공하였습니다.");
+    return true;
+  }*/
+
+  //로그인
+  @ApiOperation(value = "로그인", notes = "로그인API 입니다. 아이디와 비밀번호를 입력하세요.")
+  @PostMapping("/user/login")
+  public ResponseEntity<?> userLogin(@ModelAttribute UserInputLogin userInputLogin
+      , @ApiIgnore Errors error) {
+    List<ResponseError> responseErrorList = new ArrayList<>();
+    if (error.hasErrors()) {
+      error.getAllErrors().stream().forEach((e) -> {
+        responseErrorList.add(ResponseError.of((FieldError) e));
+      });
+      return ResponseEntity.badRequest().body(responseErrorList);
+    }
+
+    Optional<User> optionalUserser = Optional.ofNullable(
+        userRepository.findByUserId(userInputLogin.getUserId())
+            .orElseThrow(() -> new UserNotFoundException("존재하지 않는 계정입니다.")));
+    User user = optionalUserser.get();
+
+    //이메일 인증이 되어있는지 확인
+    if (!user.isEmailAuthYn()) {
+      return ResponseEntity.badRequest().body(new UserNotEmailAuthException("먼저 이메일 인증을 해주세요."));
+    }
+
+    //패스워드 확인
+    if (!userService.loginCheckPassword(userInputLogin.getPassword(), user.getPassword())) {
+      return ResponseEntity.badRequest()
+          .body(new UserLoginNotCorrectPasswordException("아이디와 비밀번호가 일치하지 않습니다."));
+    }
+    log.info("로그인 성공");
+    return ResponseEntity.ok().body("로그인에 성공하였습니다.");
+  }
+
+  //아이디 찾기
+  @ApiOperation(value = "아이디 찾기", notes = "아이디를 찾는 API 입니다. 해당하는 입력값을 넣어주세요.")
+  @GetMapping("/user/find/userId")
+  public ResponseEntity<?> findUserId(@ModelAttribute UserInputFindUserId userInputFindUserId) {
+    String userId = userService.findUserId(userInputFindUserId.getUserName(),
+        userInputFindUserId.getPhone());
+    log.info("입력한 이름 : " + userInputFindUserId.getPhone());
+    if (userId.equals("")) {
+      return ResponseEntity.badRequest().body("회원님의 아이디가 존재하지 않습니다.");
+    }
+    return ResponseEntity.ok().body("회원님의 아이디는 " + userId + "입니다.");
+  }
+
+  //비밀번호 수정
+  @ApiOperation(value = "비밀번호 수정", notes = "비밀번호 수정 API 입니다. 해당하는 입력값을 넣어주세요.")
+  @PatchMapping("/user/{id}/setPassword")
+  public ResponseEntity<?> updateUserPassword(@PathVariable Long id,
+      @ModelAttribute UserInputPassword userInputPassword
+      , @ApiIgnore Errors errors) {
+    List<ResponseError> responseErrorList = new ArrayList<>();
+    if (errors.hasErrors()) {
+      errors.getAllErrors().stream().forEach((e) -> {
+        responseErrorList.add(ResponseError.of((FieldError) e));
+      });
+      return ResponseEntity.badRequest().body(responseErrorList);
+    }
+
+    User user = userRepository.findById(id)
+        .orElseThrow(() -> new UserNotFoundException("해당하는 계정이 없습니다."));
+
+    //아이디와 비밀번호 확인
+    if (!userService.loginCheckPassword(userInputPassword.getPassword(), user.getPassword())) {
+      return ResponseEntity.badRequest()
+          .body(new UserLoginNotCorrectPasswordException("아이디와 비밀번호가 일치하지 않습니다."));
+    }
+    user.setPassword(userService.getEncryptPassword(userInputPassword.getNewPassword()));
+    userRepository.save(user);
+
+    return ResponseEntity.ok().body("비밀번호가 정상적으로 수정되었습니다.");
+  }
+
+
+  //회원탈퇴
+  @ApiOperation(value = "회원탈퇴", notes = "회원탈퇴API 입니다. 해당하는 입력값을 넣어주세요.")
+  @PostMapping("/user/delete/{id}")
+  public ResponseEntity<?> userDelete(@PathVariable Long id) {
+    User user = userRepository.findById(id)
+        .orElseThrow(() -> new UserNotFoundException("사용자 정보가 존재하지 않습니다."));
+
+    //해당 아이디의 사용자가 탈퇴를 하려는데
+    //사용자가 작성한 게시글이 있는경우 예외 발생
+
+    try {
+      userRepository.delete(user);
+    } catch (DataIntegrityViolationException e) {
+      String message = "제약조건에 문제가 발생하였습니다.";
+      return ResponseEntity.badRequest()
+          .body(message);
+    } catch (Exception e) {
+      String message = "회원 탈퇴 중 문제가 발생하였습니다.";
+      return ResponseEntity.badRequest()
+          .body(message);
+    }
+
+    return ResponseEntity.ok().body("회원 탈퇴가 정상적으로 진행되었습니다.");
+  }
+
+
+}

--- a/src/main/java/community/project/community/client/model/UserInputFindUserId.java
+++ b/src/main/java/community/project/community/client/model/UserInputFindUserId.java
@@ -1,0 +1,22 @@
+package community.project.community.client.model;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Data
+@ToString
+public class UserInputFindUserId {
+
+  //아이디 찾기
+  @NotBlank
+  private String userName;
+
+  @NotBlank
+  private String phone;
+
+}

--- a/src/main/java/community/project/community/client/repository/UserRepository.java
+++ b/src/main/java/community/project/community/client/repository/UserRepository.java
@@ -16,5 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<Object> findByIdAndPassword(long id, String password); //사용자 비밀번호 업데이트
 
+  Optional<User> findByUserNameAndPhone (String useName, String phone);
+
 
 }

--- a/src/main/java/community/project/community/client/service/UserService.java
+++ b/src/main/java/community/project/community/client/service/UserService.java
@@ -8,7 +8,8 @@ public interface UserService {
   //회원가입
   boolean register(UserInput parameter);
 
-  boolean emailAuth(String uuid); //이메일 인증
+  //이메일 인증
+  boolean emailAuth(String uuid);
 
   //패스워드 암호화
   String getEncryptPassword(String password);
@@ -21,6 +22,9 @@ public interface UserService {
 
   //패스워드 확인
   boolean loginCheckPassword(String userInputPassword, String password);
+
+  //아이디 찾기
+  String findUserId(String userName, String phone);
 
 
 

--- a/src/main/java/community/project/community/client/service/implement/UserServiceImpl.java
+++ b/src/main/java/community/project/community/client/service/implement/UserServiceImpl.java
@@ -4,6 +4,7 @@ import community.project.community.client.entity.User;
 import community.project.community.client.enums.UserRole;
 import community.project.community.client.enums.UserStatus;
 import community.project.community.client.exception.AlreadyRegistEmail;
+import community.project.community.client.exception.UserNotFoundException;
 import community.project.community.client.model.UserInput;
 import community.project.community.client.repository.UserRepository;
 import community.project.community.client.service.UserService;
@@ -13,17 +14,18 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
   private final UserRepository userRepository;
   private final MailComponents mailComponents;
-
   private final PasswordEncoder passwordEncoder;
 
   //사용자 비밀번호 암호화
@@ -53,7 +55,7 @@ public class UserServiceImpl implements UserService {
         .build();
     userRepository.save(user);
 
-    sendAuthEmail(userInput.getUserId(),uuid);
+    sendAuthEmail(userInput.getUserId(), uuid);
 
     return true;
   }
@@ -61,7 +63,7 @@ public class UserServiceImpl implements UserService {
   //동일한 이메일 체크
   @Override
   public boolean checkSameEmail(String userId) {
-    if (!userRepository.existsByUserId(userId)) {
+    if (userRepository.existsByUserId(userId)) {
       throw new AlreadyRegistEmail("이미가입된 이메일 계정입니다.");
     }
     return true;
@@ -76,6 +78,31 @@ public class UserServiceImpl implements UserService {
     mailComponents.sendMail(email, subject, text);
   }
 
+  @Override
+  public boolean emailAuth(String uuid) {
+    Optional<User> optionalUser = userRepository.findByEmailAuthKey(uuid);
+
+    if (!optionalUser.isPresent()) {
+      log.info("이메일 인증에 실패하였습니다.");
+      return false;
+    }
+    User user = optionalUser.get();
+
+    if (user.isEmailAuthYn()) {
+      log.info(optionalUser.get().getUserId() + " 회원은 이미 계정이 활성화 되었습니다.");
+      return false; //이미 해당 계정이 활성화 되었으므로 재 활성화시 false
+    }
+
+    //member.setUserStatus(Member.MEMBER_STATUS_ING);
+    user.setEmailAuthYn(true);
+    user.setEmailAuthDt(LocalDateTime.now());
+    user.setUserStatus(UserStatus.ING.toString());
+    userRepository.save(user);
+    log.info("회원아이디: " + optionalUser.get().getUserId() + " 계정이 활성화 되었습니다.");
+
+    return true;
+  }
+
   //로그인
   @Override
   public boolean loginCheckPassword(String userInputPassword, String password) {
@@ -83,6 +110,16 @@ public class UserServiceImpl implements UserService {
       return false;
     }
     return true;
+  }
+
+  @Override
+  public String findUserId(String userName, String phone) {
+    String sql = "";
+    Optional<User> user = userRepository.findByUserNameAndPhone(userName, phone);
+    if (user.isEmpty()) {
+      return "";
+    }
+    return user.get().getUserId();
   }
 
 
@@ -122,25 +159,4 @@ public class UserServiceImpl implements UserService {
   }*/
 
 
-  @Override
-  public boolean emailAuth(String uuid) {
-    Optional<User> optionalUser = userRepository.findByEmailAuthKey(uuid);
-
-    if (!optionalUser.isPresent()) {
-      return false;
-    }
-    User user = optionalUser.get();
-
-    if (user.isEmailAuthYn()) {
-      return false; //이미 해당 계정이 활성화 되었으므로 재 활성화시 false
-    }
-
-    //member.setUserStatus(Member.MEMBER_STATUS_ING);
-    user.setEmailAuthYn(true);
-    user.setEmailAuthDt(LocalDateTime.now());
-    user.setUserStatus(UserStatus.ING.toString());
-    userRepository.save(user);
-
-    return true;
-  }
 }

--- a/src/main/java/community/project/community/client/service/implement/UserServiceImpl.java
+++ b/src/main/java/community/project/community/client/service/implement/UserServiceImpl.java
@@ -112,11 +112,14 @@ public class UserServiceImpl implements UserService {
     return true;
   }
 
+  //유저 아이디 찾기
   @Override
   public String findUserId(String userName, String phone) {
-    String sql = "";
+
+    //이름+연락처 조합으로 사용자 찾기
     Optional<User> user = userRepository.findByUserNameAndPhone(userName, phone);
     if (user.isEmpty()) {
+      //유저가 없는 경우
       return "";
     }
     return user.get().getUserId();

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <property name="LOG_DIR" value="./"/>
+  <property name="LOG_FILE_NAME" value="Community_log"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- 로그 기록 패턴과 하이라이트(글자색) 설정 -->
+      <pattern> %d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %magenta(%-4relative) --- [ %thread{10} ] %cyan(%logger{20}) : %msg%n </pattern>
+    </encoder>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_DIR}/${LOG_FILE_NAME}.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_DIR}/${LOG_FILE_NAME}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+      <!-- 로그파일 최대 허용 용량 10MB -->
+      <maxFileSize>10MB</maxFileSize>
+      <!-- 최대 30일 보간 -->
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="org.springframework" level="info"/>
+  <logger name="org.hibernate" level="info"/>
+  <root level="info">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
+</configuration>


### PR DESCRIPTION
<5주차>

1. 아이디 찾기 
- 유저의 이름과 연락처 (고유) 로 회원의 아이디를 찾기 가능

2. 이메일 인증(계정 활성화)
- RestController가 아닌 일반 Controller에서 처리, 계정 활성화 페이지로 이동

3. 게시글 삭제
- 삭제를 시도하는 유저와 게시글을 작성한 유저의 일치여부 확인 추가

4. 댓글 작성 기능
- 게시글의 댓글을 저장해주는 entity 정의, 댓글 작성 기능 구현

## Summary
- 유저 아이디 찾기
- 이메일 인증 로직 수정
- 게시글 삭제 로직 수정
- 댓글 작성 

## Describe your changes
- 유저의 이름과 연락처 (고유) 로 회원의 아이디를 찾는 기능을 구현했습니다.
- 이메일 인증 로직을 RestController가 아닌 일반 Controller에서 처리, 계정 활성화 페이지로 이동하게끔 변경했습니다.
- 이메일 인증 결과를 화면에 나타내 주는 html를 추가하였습니다.
- 게시글 삭제 로직을 삭제를 시도하는 유저와 게시글을 작성한 유저의 일치여부를 확인하도록 변경했습니다.
- 댓글 작성 정보를 저장하는 entity를 정의하였습니다.
- entity는 댓글을 작성하는 User와 작성되는 게시글 Board를 참조하도록 설계하였습니다.
- 댓글 작성 기능을 구현하였습니다.

## Issue number and link
